### PR TITLE
A few timing fixes

### DIFF
--- a/asspull.h
+++ b/asspull.h
@@ -21,6 +21,7 @@ enum logCategories
 };
 
 extern int Lerp(int a, int b, float f);
+extern int GreatestCommonDivisor(int a, int b);
 extern unsigned int RoundUp(unsigned int v);
 extern int Slurp(unsigned char* dest, const WCHAR* filePath, unsigned int* size);
 extern int Dump(const WCHAR* filePath, unsigned char* source, unsigned long size);

--- a/extras.cpp
+++ b/extras.cpp
@@ -7,6 +7,17 @@ int Lerp(int a, int b, float f)
 	return (int)((b - a) * f + a);
 }
 
+int GreatestCommonDivisor(int a, int b)
+{
+	while (b != 0)
+	{
+		int t = b;
+		b = a % b;
+		a = t;
+	}
+	return a;
+}
+
 unsigned int RoundUp(unsigned int v)
 {
 	v--;

--- a/main.cpp
+++ b/main.cpp
@@ -491,7 +491,7 @@ void MainLoop()
 				cycles -= m68k_execute(cycles / cpuDivider) * cpuDivider;
 			}
 
-			if (line == lines)
+			if (line + 1 == lines)
 			{
 				if (pauseState == pauseEntering) //pausing now!
 				{

--- a/main.cpp
+++ b/main.cpp
@@ -220,6 +220,7 @@ void MainLoop()
 	auto endTime = 0;
 	auto delta = 0;
 	auto frames = 0;
+	auto cycles = 0;
 
 	bool gottaReset = false;
 
@@ -473,18 +474,21 @@ void MainLoop()
 		{
 			if (line < lines)
 			{
-				m68k_execute(pixsPerRow * pixDivider / cpuDivider);
+				cycles += pixsPerRow * pixDivider;
+				cycles -= m68k_execute(cycles / cpuDivider) * cpuDivider;
 
 				HandleHdma(line);
 				Video::RenderLine(line);
 				for (int i = 0; i < MAXDEVS; i++)
 					if (devices[i] != NULL) devices[i]->HBlank();
 
-				m68k_execute(hBlankPixs * pixDivider / cpuDivider);
+				cycles += hBlankPixs * pixDivider;
+				cycles -= m68k_execute(cycles / cpuDivider) * cpuDivider;
 			}
 			else
 			{
-				m68k_execute(trueWidth * pixDivider / cpuDivider);
+				cycles += trueWidth * pixDivider;
+				cycles -= m68k_execute(cycles / cpuDivider) * cpuDivider;
 			}
 
 			if (line == lines)


### PR DESCRIPTION
- Reconcile CPU and pixel clocks
- Track cycles across execute calls
- Start VBlank on the correct line
- Allow arbitrary adjustment of CPU and pixel clocks