### PR TITLE
Assign VBlank to IRQ 6 and HBlank to IRQ 4 

### DIFF
--- a/docs/bios.md
+++ b/docs/bios.md
@@ -19,7 +19,7 @@ typedef struct IBios
 	int16_t extensions;
 	void(*Exception)(void);
 	void(*VBlank)(void);
-	void(*reserved)(void);
+	void(*HBlank)(void);
 	void(*DrawChar)(char ch, int32_t x, int32_t y, int32_t color);
 	ITextLibrary* textLibrary;
 	IDrawingLibrary* drawingLibrary;
@@ -34,8 +34,8 @@ typedef struct IBios
 * `biosVersion`: the BIOS/interface revision in 8.8 fixed point, so `0x0102` means version 1.2.
 * `extensions`: reserved.
 * `Exception`: a function pointer to a generic exception handler, not currently used.
-* `VBlank`: a function pointer called by ~~the BIOS' interrupt dispatcher~~ `MISC->WaitForVblank` when not null. May be set by programs as needed.
-* `reserved`: exactly that.
+* `VBlank`: a function pointer called by the BIOS' interrupt dispatcher when not null. May be set by programs as needed.
+* `HBlank`: as above, but for HBlank.
 * `DrawChar`: a function pointer to a routine that draws characters,  Automatically set to BIOS-provided routines by the `SetBitmapMode` interface calls.
 * `textLibrary`, `drawingLibrary`, `miscLibrary`, and `diskLibrary`: substructures with function pointers to various interface calls.
 * `DrawCharFont`: a pointer to the font graphics data that `DrawChar` may use.

--- a/docs/registers.md
+++ b/docs/registers.md
@@ -2,13 +2,14 @@
 
 ### 00000	REG_INTRMODE
 
-    X... .V..
-    |     |____ VBlank triggered
+    X... .VH.
+    |     |____ HBlank active
+    |     |____ VBlank active
     |__________ Disable interrupts
 
-Used by the BIOS dispatcher to determine what to call. Applications can set the disable bit to prevent them from firing. Only VBlank is supported for now.
+Applications can set the disable bit to prevent interrupts from firing. The active bits can be used for polling independent of whether interrupts are disabled.
 
-Available defines: `IMODE_DISABLE`, `IMODE_INVBLANK`
+Available defines: `IMODE_DISABLE`, `IMODE_INVBLANK`, `IMODE_INHBLANK`
 
 ### 00001	REG_SCREENMODE
 

--- a/musashi/m68kconf.h
+++ b/musashi/m68kconf.h
@@ -88,7 +88,7 @@
  * If off, all interrupts will be autovectored and all interrupt requests will
  * auto-clear when the interrupt is serviced.
  */
-#define M68K_EMULATE_INT_ACK        OPT_OFF
+#define M68K_EMULATE_INT_ACK        OPT_ON
 #define M68K_INT_ACK_CALLBACK(A)    your_int_ack_handler_function(A)
 
 


### PR DESCRIPTION
Rather than a single NMI for VBlank, separate maskable interrupts are now raised for VBlank and HBlank. They are automatically deasserted on acknowledgement, so no work is necessary in the ISR.

As the low bits of REG_INTRMODE are no longer needed for their original purpose, they are now set for the duration of V/HBlank irrespective of interrupt status, allowing applications to poll for blanking periods if desired.

For now this PR includes some prior unmerged commits, but I'll rebase this branch on master once they are in.
